### PR TITLE
feat(professors): add CRUD, views, and shared alerts

### DIFF
--- a/app/Http/Controllers/ProfessorController.php
+++ b/app/Http/Controllers/ProfessorController.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Professor;
+use Illuminate\Http\Request;
+
+class ProfessorController extends Controller
+{
+    /*public function __construct(){
+        // Solamente los administradores podrán gestionar los datos de los profesores
+        $this->middleware(['auth', 'role:admin']);
+    }*/
+
+    /**
+     * Display a listing of the resource.
+    */
+    public function index(Request $request)
+    {
+        $query = Professor::query();
+
+        if ($search = $request->input('search')) {
+            $query->where(fn($q)=>
+                $q->where('first_name', 'like', "%{$search}%")
+                ->orWhere('last_name', 'like', "%{$search}%")
+                ->orWhere('email', 'like', "%{$search}%")
+            );
+        }
+
+        if ($initial = $request->input('initial')) {
+            $query->where('last_name', 'like', "{$initial}%");
+        }
+
+        if ($sort = $request->input('sort')) {
+            match($sort) {
+                'name_asc'  => $query->orderBy('last_name', 'asc'),
+                'name_desc' => $query->orderBy('last_name', 'desc'),
+                'newest'    => $query->orderBy('created_at', 'desc'),
+                'oldest'    => $query->orderBy('created_at', 'asc'),
+                default     => null
+            };
+        }
+
+        $professors = $query->paginate(10)->withQueryString();
+
+        return view('professors.index', compact('professors'));
+    }
+ 
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        return view('professors.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'first_name' => 'required|string|max:255',
+            'last_name'  => 'required|string|max:255',
+            'email'      => 'required|email|unique:professors,email',
+            'password'   => 'required|string|min:8|confirmed',
+        ], [
+            'first_name.required' => 'El nombre es obligatorio.',
+            'last_name.required'  => 'El apellido es obligatorio.',
+            'email.required'      => 'El correo electrónico es obligatorio.',
+            'email.email'         => 'El correo electrónico debe ser válido.',
+            'email.unique'        => 'El correo electrónico ya está en uso.',
+            'password.required'   => 'La contraseña es obligatoria.',
+            'password.min'        => 'La contraseña debe tener al menos 8 caracteres.',
+            'password.confirmed'  => 'Las contraseñas no coinciden.',
+        ]);
+
+        $data['password'] = bcrypt($data['password']);
+
+        Professor::create($data);
+        return redirect()->route('professors.index')
+            ->with('alert', [
+                'type'    => 'success', 
+                'message' => 'Profesor creado exitosamente.'
+            ]);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Professor $professor)
+    {
+        return view('professors.show', compact('professor'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Professor $professor)
+    {
+        return view('professors.edit', compact('professor'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Professor $professor)
+    {
+        $data = $request->validate([
+            'first_name' => 'required|string|max:255',
+            'last_name'  => 'required|string|max:255',
+            'email'      => 'required|email|unique:professors,email,' . $professor->id,
+            'password'   => $request->filled('password') ? 'string|min:8|confirmed' : 'nullable',
+        ], [
+            'first_name.required' => 'El nombre es obligatorio.',
+            'last_name.required'  => 'El apellido es obligatorio.',
+            'email.required'      => 'El correo electrónico es obligatorio.',
+            'email.email'         => 'El correo electrónico debe ser válido.',
+            'email.unique'        => 'El correo electrónico ya está en uso.',
+            'password.min'        => 'La contraseña debe tener al menos 8 caracteres.',
+            'password.confirmed'  => 'Las contraseñas no coinciden.',
+        ]);
+
+        // Se "hasheará" la contraseña al proporcionarse una nueva
+        if ($request->filled('password')) {
+            $data['password'] = bcrypt($request->input('password'));
+        } else {
+            unset($data['password']);
+        }
+
+        $professor->update($data);
+        return redirect()->route('professors.index')
+            ->with('alert', [
+                'type'    => 'success',
+                'message' => 'Profesor actualizado exitosamente.'
+            ]);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Professor $professor)
+    {
+        // En caso que el profesor tenga cursos relacionados, estos serán eliminados
+        /* if ($professor->courses()->exists()) {
+            $professor->courses()->delete();
+        } */
+
+        $professor->delete();
+        return redirect()->route('professors.index')
+            ->with('alert', [
+                'type'    => 'success',
+                'message' => 'Profesor eliminado exitosamente.'
+            ]);
+    }
+}

--- a/app/Models/Professor.php
+++ b/app/Models/Professor.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Professor extends Model
+{
+    protected $fillable = [
+        'first_name',
+        'last_name',
+        'email',
+        'password'
+    ];
+
+    protected $hidden = [
+        'password',
+    ];
+
+    /** 
+     * Mutator para encriptar la contraseña antes de guardarla en la base de datos.
+    */
+    public function setPasswordAttribute($value)
+    {
+        $this->attributes['password'] = bcrypt($value);
+    }
+
+    public function getFullName(){
+        return $this->first_name . ' ' . $this->last_name;
+    }
+}

--- a/database/migrations/2025_06_11_211122_create_professors_table.php
+++ b/database/migrations/2025_06_11_211122_create_professors_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('professors', function (Blueprint $table) {
+            $table->id();
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('professors');
+    }
+};

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -12,6 +12,7 @@
         <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"/>
         <script src="https://kit.fontawesome.com/2af02d949f.js" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])
@@ -33,7 +34,8 @@
             <main>
                 {{ $slot }}
             </main>
-            
+            @include('partials.alerts')
+
             @stack('scripts')
         </div>
     </body>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -15,6 +15,9 @@
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-nav-link>
+                    <x-nav-link href="{{ route('professors.index')}}" :active="request()->routeIs('professors.*')">
+                        {{ __('Profesores') }}
+                    </x-nav-link>
                     <x-nav-link href="{{ route('about') }}" :active="request()->routeIs('about')">
                         <i class="fa-solid fa-circle-info mr-2"></i>
                         {{ __('Acerca de') }}

--- a/resources/views/pages/about.blade.php
+++ b/resources/views/pages/about.blade.php
@@ -1,39 +1,40 @@
+{{-- filepath: c:\laragon\www\Web-Design-Final-Project\resources\views\pages\about.blade.php --}}
 <x-app-layout>
-    <div id="about" class="relative py-24 bg-gradient-to-r from-cyan-500 to-teal-300 dark:from-gray-900 dark:to-gray-800 overflow-hidden">
-        <div class="absolute -top-16 -left-16 w-72 h-72 bg-cyan-400/20 dark:bg-cyan-700/20 rounded-full blur-3xl"></div>
-        <div class="absolute -bottom-16 -right-16 w-96 h-96 bg-teal-300/20 dark:bg-teal-600/20 rounded-full blur-3xl"></div>
+    <div id="about" class="relative py-24 bg-gradient-to-r from-[#31c0d3]/10 to-[#0b545b]/10 dark:from-gray-900 dark:to-gray-800 overflow-hidden select-none">
+        <div class="absolute -top-16 -left-16 w-72 h-72 bg-[#31c0d3]/20 dark:bg-cyan-700/20 rounded-full blur-3xl"></div>
+        <div class="absolute -bottom-16 -right-16 w-96 h-96 bg-[#0b545b]/20 dark:bg-teal-600/20 rounded-full blur-3xl"></div>
 
         <div class="px-4 sm:px-6 lg:px-8">
             <div class="max-w-7xl mx-auto">
                 <!-- Título principal y un poco de contexto sobre el sistema -->
-                <div class="max-w-3xl mx-auto text-center mb-16" data-animate="animate__fadeInDown">
-                    <h2 class="text-5xl sm:text-6xl font-extrabold text-gray-800 dark:text-gray-100 mb-4">
-                        Acerca de <span class="text-cyan-600 dark:text-cyan-400 relative inline-block">Justificaciones UAM</span>
+                <div class="max-w-3xl mx-auto text-center mb-16 opacity-0 transition-opacity duration-500" data-animate="animate__fadeInDown">
+                    <h2 class="text-5xl sm:text-6xl font-extrabold text-[#231f20] dark:text-gray-100 mb-4">
+                        Acerca de <span class="text-[#31c0d3] dark:text-cyan-400 relative inline-block font-black">Justificaciones UAM</span>
                     </h2>
-                    <p class="mt-6 text-lg text-white dark:text-gray-300 leading-relaxed">
+                    <p class="mt-6 text-lg text-[#231f20] dark:text-gray-300 leading-relaxed">
                         El <strong>Sistema de Gestión de Justificaciones</strong> de la Universidad Americana (UAM) digitaliza y automatiza el proceso de justificación de inasistencias, la generación de reportes estadísticos y la reprogramación de evaluaciones. Con una plataforma segura, rápida e intuitiva, optimizamos la eficiencia de coordinadores, secretaría, docentes y estudiantes.
                     </p>
                 </div>
 
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-10 mb-20">
                     <!-- Mision UAM -->
-                    <div class="p-8 bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm rounded-xl shadow-xl transform transition hover:scale-105 group" data-animate="animate__fadeInLeft">
-                        <div class="flex items-center justify-center w-14 h-14 mb-4 bg-cyan-500 dark:bg-cyan-700 text-white rounded-full">
+                    <div class="p-8 bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm rounded-xl shadow-xl transform opacity-0 transition-opacity duration-500 hover:scale-105 group" data-animate="animate__fadeInLeft">
+                        <div class="flex items-center justify-center w-14 h-14 mb-4 bg-[#31c0d3] dark:bg-[#0b545b] text-white rounded-full">
                             <i class="fas fa-bullseye"></i>
                         </div>
-                        <h3 class="text-2xl font-semibold text-gray-800 dark:text-gray-100 mb-2">{{ __('Misión') }}</h3>
-                        <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+                        <h3 class="text-2xl font-semibold text-[#231f20] dark:text-gray-100 mb-2">{{ __('Misión') }}</h3>
+                        <p class="text-[#231f20] dark:text-gray-300 leading-relaxed">
                             Formar líderes con visión global, emprendedores, con sólidos conocimientos científicos y principios humanísticos, capaces de aprender permanentemente para enfrentar los desafíos de la sociedad contemporánea.
                         </p>
                     </div>
                     
                     <!-- Visión UAM -->
-                    <div class="p-8 bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm rounded-xl shadow-xl transform transition hover:scale-105 group" data-animate="animate__fadeInRight">
-                        <div class="flex items-center justify-center w-14 h-14 mb-4 bg-cyan-500 dark:bg-cyan-700 text-white rounded-full">
+                    <div class="p-8 bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm rounded-xl shadow-xl transform opacity-0 transition-opacity duration-500 hover:scale-105 group" data-animate="animate__fadeInRight">
+                        <div class="flex items-center justify-center w-14 h-14 mb-4 bg-[#31c0d3] dark:bg-[#0b545b] text-white rounded-full">
                             <i class="fas fa-eye"></i>
                         </div>
-                        <h3 class="text-2xl font-semibold text-gray-800 dark:text-gray-100 mb-2">{{ __('Visión') }}</h3>
-                        <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+                        <h3 class="text-2xl font-semibold text-[#231f20] dark:text-gray-100 mb-2">{{ __('Visión') }}</h3>
+                        <p class="text-[#231f20] dark:text-gray-300 leading-relaxed">
                             Consolidarse como institución académica de clase internacional comprometida con el desarrollo humano equitativo y sostenible, con la eficiencia y competitividad de una organización privada de alto rendimiento.
                         </p>
                     </div>
@@ -51,17 +52,17 @@
                     ]
                 @endphp
 
-                <h3 class="text-3xl font-bold text-gray-800 dark:text-gray-100 text-center mb-8" data-animate="animate__fadeInUp">
+                <h3 class="text-3xl font-bold text-[#231f20] dark:text-gray-100 text-center mb-8 opacity-0 transition-opacity duration-500" data-animate="animate__fadeInUp">
                     Principios que nos guían
                 </h3>
 
-                <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-8" data-animate="animate__zoomIn">
+                <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-8 opacity-0 transition-opacity duration-500" data-animate="animate__zoomIn">
                     @foreach ($values as $value)
                         <div class="flex flex-col items-center p-6 bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm rounded-xl shadow-md transform transition hover:scale-110 group">
-                            <div class="flex items-center justify-center w-12 h-12 mb-3 bg-cyan-600 dark:bg-cyan-700 text-white rounded-full">
+                            <div class="flex items-center justify-center w-12 h-12 mb-3 bg-[#31c0d3] dark:bg-[#0b545b] text-white rounded-full">
                                 <i class="{{ $value['icon'] }}"></i>
                             </div>
-                            <p class="text-sm font-medium text-gray-800 dark:text-gray-200 text-center">
+                            <p class="text-sm font-medium text-[#231f20] dark:text-gray-200 text-center">
                                 {{ $value['label'] }}
                             </p>
                         </div>
@@ -85,7 +86,8 @@
       entries.forEach(entry => {
         if (!entry.isIntersecting) return; // Si el elemento no está lo bastante visible, se ignora
 
-        // Se añaden las clases de animate.css para disparar la animación
+        // Se quita la opacidad del componente y se añaden las clases de animate.css para disparar la animación
+        entry.target.classList.remove('opacity-0');
         entry.target.classList.add(
           'animate__animated',
           entry.target.dataset.animate

--- a/resources/views/partials/alerts.blade.php
+++ b/resources/views/partials/alerts.blade.php
@@ -1,0 +1,60 @@
+{{-- 
+    Script centralizado para gestionar alertas y confirmaciones en todo el proyecto utilizando SweetAlert2, 
+    basado en diferentes casos de uso
+--}}
+@push('scripts')
+<script>
+// Toast genérico
+const Toast = Swal.mixin({
+    toast: true,
+    position: 'top-end',
+    showConfirmButton: false,
+    timer: 3000,
+    timerProgressBar: true,
+    theme: 'auto',
+    didOpen: t => {
+        t.addEventListener('mouseenter', Swal.stopTimer);
+        t.addEventListener('mouseleave', Swal.resumeTimer);
+    }
+});
+
+/**
+ *  Modal de éxito al crear/editar/eliminar, 
+ *  usando los mensajes especificados desde los métodos de los controladores:
+ *     e.g.: ->with('alert', ['type'=>'success','message'=>'¡... creado/editado/eliminado correctamente!'])
+ */
+@if(session('alert'))
+    Toast.fire({
+        icon: '{{ session("alert.type") }}',
+        title: @json(session('alert.message'))
+    });
+@endif
+
+// Modales genéricas para confirmación de acciones
+document.querySelectorAll('.swal-confirm').forEach(btn =>
+    btn.addEventListener('click', e => {
+        e.preventDefault();
+
+        // Parámetros especificados en las vistas desde atributos data-*
+        const title     = btn.dataset.title     || '¿Estás seguro?';
+        const text      = btn.dataset.text      || '';
+        const icon      = btn.dataset.icon      || 'warning';
+        const confirm   = btn.dataset.confirm   || 'Sí'
+        const cancel    = btn.dataset.cancel    || 'Cancelar';
+        const formId    = btn.dataset.formId; // Id del formulario a enviar
+        const form      = formId ? document.getElementById(formId) : btn.closest('form');
+
+        Swal.fire({
+            theme: 'auto',
+            icon: icon,
+            title: title,
+            text: text,
+            showCancelButton: true,
+            confirmButtonText: confirm,
+            cancelButtonText: cancel,
+            confirmButtonColor: '#dc2626'
+        }).then(res => res.isConfirmed && form.submit())
+    })
+);
+</script>
+@endpush

--- a/resources/views/professors/_form.blade.php
+++ b/resources/views/professors/_form.blade.php
@@ -1,0 +1,89 @@
+<!--
+    Este formulario es utilizado para ambas acciones de creación y edición de un profesor.
+    La variable $isEdit se usa aquí para determinar si estamos en el modo de edición o creación, respectivamente.
+    Si $isEdit es verdadero, se mostrará el formulario de edición, de lo contrario, se mostrará el formulario de creación.
+-->
+
+@php
+    // Aquí se detecta si estamos en edición (se pasó $professor) o creación
+    $isEdit = isset($professor) && $professor !== null;
+@endphp
+
+<form action="{{ $isEdit ? route('professors.update', $professor) : route('professors.store') }}" method="POST" class="space-y-6" novalidate autocomplete="off">
+    @csrf
+    @if($isEdit)
+        @method('PUT')
+    @endif
+    
+    <!-- Campo de nombres del profesor -->
+    <div>
+        <label for="first_name" class="block text-sm font-medium text-[#231f20] dark:text-gray-200 mb-1">
+            {{ __('Nombres') }}
+        </label>
+        <input type="text" name="first_name" id="first_name" value="{{ old('first_name', $professor->first_name ?? '') }}" placeholder="e.g.: Juan" class="block w-full px-4 py-2 bg-white/80 dark:bg-gray-700 border border-[#0b545b]/20 dark:border-gray-600 rounded-lg text-[#231f20] dark:text-gray-100 placeholder-[#0b545b]/50 dark:placeholder-[#ffffff]/20 focus:outline-none focus:ring-2 focus:ring-[#31c0d3] focurs:border-[#31c0d3] transition"/>
+        <div class=" @error('first_name') flex @else hidden @enderror items-center gap-1.5 text-red-600 dark:text-red-400 text-xs mt-1 bg-red-50 dark:bg-[#3C0000] p-1.5 border border-red-300 dark:border-red-700 rounded">
+            <i class="fa-solid fa-circle-exclamation"></i>
+            <span>@error('first_name'){{ $message }}@enderror</span>
+        </div>
+    </div>
+
+    <!-- Campo de apellidos del profesor -->
+    <div>
+        <label for="last_name" class="block text-sm font-medium text-[#231f20] dark:text-gray-200 mb-1">
+            {{ __('Apellidos') }}
+        </label>
+        <input type="text" name="last_name" id="last_name" value="{{ old('last_name', $professor->last_name ?? '') }}" placeholder="e.g.: Pérez" class="block w-full px-4 py-2 bg-white/80 dark:bg-gray-700 border border-[#0b545b]/20 dark:border-gray-600 rounded-lg text-[#231f20] dark:text-gray-100 placeholder-[#0b545b]/50 dark:placeholder-[#ffffff]/20 focus:outline-none focus:ring-2 focus:ring-[#31c0d3] focurs:border-[#31c0d3] transition"/>
+        <div class=" @error('last_name') flex @else hidden @enderror items-center gap-1.5 text-red-600 dark:text-red-400 text-xs mt-1 bg-red-50 dark:bg-[#3C0000] p-1.5 border border-red-300 dark:border-red-700 rounded">
+            <i class="fa-solid fa-circle-exclamation"></i>
+            <span>@error('last_name'){{ $message }}@enderror</span>
+        </div>
+    </div>
+
+    <!-- Campo de correo electrónico del profesor -->
+    <div>
+        <label for="email" class="block text-sm font-medium text-[#231f20] dark:text-gray-200 mb-1">
+            {{ __('Correo electrónico') }}
+        </label>
+        <input type="text" name="email" id="email" value="{{ old('email', $professor->email ?? '') }}" placeholder="e.g.: usuario@uamv.edu.ni" class="block w-full px-4 py-2 bg-white/80 dark:bg-gray-700 border border-[#0b545b]/20 dark:border-gray-600 rounded-lg text-[#231f20] dark:text-gray-100 placeholder-[#0b545b]/50 dark:placeholder-[#ffffff]/20 focus:outline-none focus:ring-2 focus:ring-[#31c0d3] focurs:border-[#31c0d3] transition"/>
+        <div class=" @error('email') flex @else hidden @enderror items-center gap-1.5 text-red-600 dark:text-red-400 text-xs mt-1 bg-red-50 dark:bg-[#3C0000] p-1.5 border border-red-300 dark:border-red-700 rounded"> 
+            <i class="fa-solid fa-circle-exclamation"></i>
+            <span>@error('email'){{ $message }}@enderror</span>
+        </div>
+    </div>
+
+    <!-- Campo de contraseña del profesor (requerida sólo en creación) -->
+    <div>
+        <label for="password" class="block text-sm font-medium text-[#231f20] dark:text-gray-200 mb-1">
+            {{ $isEdit ? __('Nueva contraseña (opcional)') : __('Contraseña') }}
+        </label>
+        <input type="password" name="password" id="password" value="{{ old('password') }}" placeholder="{{ $isEdit ? __('Déjala en blanco para no cambiarla') : ''}}" class="block w-full px-4 py-2 bg-white/80 dark:bg-gray-700 border border-[#0b545b]/20 dark:border-gray-600 rounded-lg text-[#231f20] dark:text-gray-100 placeholder-[#0b545b]/50 dark:placeholder-[#ffffff]/20 focus:outline-none focus:ring-2 focus:ring-[#31c0d3] focurs:border-[#31c0d3] transition"/>
+        <div class=" @error('password') flex @else hidden @enderror items-center gap-1.5 text-red-600 dark:text-red-400 text-xs mt-1.5 bg-red-50 dark:bg-[#3C0000] p-1.5 border border-red-300 dark:border-red-700 rounded"> 
+            <i class="fa-solid fa-circle-exclamation"></i>
+            <span>@error('password'){{ $message }}@enderror</span>
+        </div>
+    </div>
+
+    <!-- Campo de confirmación de contraseña -->
+    <div>
+        <label for="password_confirmation" class="block text-sm font-medium text-[#231f20] dark:text-gray-200 mb-1">
+            {{ __('Confirmar contraseña') }}
+        </label>
+        <input type="password" name="password_confirmation" id="password_confirmation" value="{{ old('password_confirmation') }}" placeholder="{{ $isEdit ? __('—') : '' }}" class="block w-full px-4 py-2 bg-[#ffffff]/80 dark:bg-gray-700 border border-[#0b545b]/20 dark:border-gray-600 rounded-lg text-[#231f20] dark:text-gray-100 placeholder-[#0b545b]/50 dark:placeholder-[#ffffff]/20 focus:outline-none focus:ring-2 focus:ring-[#31c0d3] focus:border-[#31c0d3] transition"/>
+        <div class=" @error('password') flex @else hidden @enderror items-center gap-1.5 text-red-600 dark:text-red-400 text-xs mt-1.5 bg-red-50 dark:bg-[#3C0000] p-1.5 border border-red-300 dark:border-red-700 rounded"> 
+            <i class="fa-solid fa-circle-exclamation"></i>
+            <span>@error('password'){{ $message }}@enderror</span>
+        </div>        
+    </div>
+
+    <!-- Botones de acción -->
+    <div class="flex flex-col gap-3">
+        <button type="submit" class="w-full inline-flex justify-center items-center gap-2 px-5 py-3 bg-[#31c0d3] hover:bg-[#0b545b] dark:bg-[#0b545b] dark:hover:bg-[#31c0d3] text-white font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-[#31c0d3] dark:focus:ring-offset-gray-900 transition-all">
+            <i class="fas {{ $isEdit ? 'fa-user-edit' : 'fa-user-plus' }}"></i>
+            {{ $isEdit ? __('Actualizar Profesor') : __('Crear Profesor') }}
+        </button>
+        <a href="{{ route('professors.index') }}" class="w-full inline-flex justify-center items-center gap-2 px-4 py-2 text-[#231f20] dark:text-gray-300 hover:bg-[#31c0d3]/10 dark:hover:bg-gray-700 rounded-lg transition">
+            <i class="fas fa-arrow-left"></i>
+            {{ __('Cancelar') }}
+        </a>
+    </div>
+</form>

--- a/resources/views/professors/create.blade.php
+++ b/resources/views/professors/create.blade.php
@@ -1,0 +1,16 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex items-center gap-2">
+            <i class="fas fa-chalkboard-teacher text-2xl text-[#31c0d3] dark:text-[#31c0d3] mr-2"></i>
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-100">
+                {{ __('Crear Profesor') }}
+            </h2>
+        </div>
+    </x-slot>
+
+    <div class="min-h-screen py-12 bg-white/10 dark:bg-gray-900 transition-colors">
+        <div class="max-w-lg mx-auto bg-white/80 dark:bg-gray-800/80 border border-[#0b545b]/20 dark:border-gray-700 shadow-lg p-8 rounded-2xl">
+            @include('professors._form')
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/professors/edit.blade.php
+++ b/resources/views/professors/edit.blade.php
@@ -1,0 +1,17 @@
+{{-- resources/views/professors/edit.blade.php --}}
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex items-center gap-2">
+            <i class="fas fa-user-edit text-2xl text-[#31c0d3] dark:text-[#31c0d3] mr-2"></i>
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-100">
+                {{ __('Editar Profesor') }}
+            </h2>
+        </div>
+    </x-slot>
+
+    <div class="min-h-screen py-12 bg-white/10 dark:bg-gray-900 transition-colors">
+        <div class="max-w-lg mx-auto bg-white/80 dark:bg-gray-800/80 border border-[#0b545b]/20 dark:border-gray-700 shadow-lg p-8 rounded-2xl">
+            @include('professors._form', ['professor' => $professor])
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/professors/index.blade.php
+++ b/resources/views/professors/index.blade.php
@@ -1,0 +1,168 @@
+{{-- resources/views/professors/index.blade.php --}}
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex items-center justify-between">
+            <div class="flex items-center gap-3">
+                <span class="inline-flex items-center justifiy-center w-10 h-10 rounded-full bg-[#31c0d3]/20 dark:bg-[#0b545b]/30">
+                    <i class="fas fa-chalkboard-teacher text-xl text-[#31c0d3] dark:text-[#31c0d3] dark:bg-[#0b545b]/30 mr-2"></i>
+                </span>
+                <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-100">
+                    {{ __('Profesores') }}
+                </h2>
+            </div>
+            <a href="{{ route('professors.create') }}"
+               class="inline-flex items-center gap-2 px-4 py-2 bg-[#31c0d3] hover:bg-[#0b545b] dark:bg-[#0b545b] dark:hover:bg-[#31c0d3] text-white font-semibold rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#31c0d3] dark:focus:ring-offset-gray-900 transition">
+                <i class="fas fa-plus"></i>
+                {{ __('Crear Profesor') }}
+            </a>
+        </div>
+    </x-slot>
+
+    <div class="py-8 sm:py-12 bg-gradient-to-r from-[#31c0d3]/10 to-[#0b545b]/10 dark:from-gray-900 dark:to-gray-800 min-h-screen">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <!-- Sección de búsqueda y filtrado -->
+            <form method="GET" action="{{ route('professors.index') }}" class="flex flex-col sm:flex-row items-stretch sm:items-center justify-between mb-6 gap-4">
+                <!-- Búsqueda con icono y botón integrado -->
+                <div class="relative flex-1 max-w-full">
+                    <span class="absolute inset-y-0 left-0 flex items-center pl-3 text-[#31c0d3] dark:text-[#31c0d3]">
+                        <i class="fas fa-search"></i>
+                    </span>
+                    <input type="text" name="search" value="{{ request('search') }}" placeholder="{{ __('Buscar profesor por nombre o correo...') }}" class="w-full pl-10 pr-16 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#31c0d3] focus:border-[#31c0d3] transition"/>
+                    <button type="submit" class="absolute right-2 top-1/2 -translate-y-1/2 px-3 py-1.5 bg-[#31c0d3] hover:bg-[#0b545b] text-white rounded-lg transition flex items-center gap-1 shadow" title="{{ __('Buscar') }}">
+                        <i class="fas fa-arrow-right"></i>
+                        <span class="sr-only">{{ __('Buscar') }}</span>
+                    </button>
+                </div>
+
+                <!-- Filtro mejorado con icono -->
+                <div class="flex items-center gap-2">
+                    <label for="sort" class="sr-only">{{ __('Filtrar') }}</label>
+                    <div class="relative">
+                        <span class="absolute inset-y-0 left-0 flex items-center pl-3 text-[#31c0d3] dark:text-[#31c0d3]">
+                            <i class="fas fa-filter"></i>
+                        </span>
+                        <select name="sort" id="sort" onchange="this.form.submit()" class="pl-10 pr-8 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-[#31c0d3] focus:border-[#31c0d3] transition appearance-none" title="{{ __('Filtrar lista de profesores') }}">
+                            <option value="">{{ __('Filtrar') }}</option>
+                            <option value="name_asc"  @selected(request('sort')==='name_asc')>{{ __('Nombre A-Z') }}</option>
+                            <option value="name_desc" @selected(request('sort')==='name_desc')>{{ __('Nombre Z-A') }}</option>
+                        </select>
+                        <span class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400">
+                            <i class="fas fa-chevron-down"></i>
+                        </span>
+                    </div>
+                </div>
+            </form>
+
+            <!-- Tabla responsiva -->
+            <div class="overflow-x-auto bg-white/80 dark:bg-gray-800/800 shadow-xl rounded-xl">
+                <table class="min-w-full divide-y divide-[#0b545b]/20 dark:divide-gray-700">
+                    <thead class="bg-[#31c0d3] dark:bg-[#0b545b]">
+                        <tr>
+                            <th class="px-6 py-3 text-left text-sm font-semibold text-white">
+                                {{ __('Nombre Completo') }}
+                            </th>
+                            <th class="px-6 py-3 text-left text-sm font-semibold text-white">
+                                {{ __('Correo') }}
+                            </th>
+                            <th class="px-6 py-3 text-center text-sm font-semibold text-white">
+                                {{ __('Acciones') }}
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white dark:bg-gray-900 divide-y divide-[#0b545b]/20 dark:divide-gray-700">
+                        @forelse ($professors as $professor)
+                            <tr class="even:bg-[#31c0d3]/10 dark:even:bg-gray-800 transition">
+                                <!-- Nombre completo -->
+                                <td class="px-6 py-4 text-[#231f20] dark:text-gray-300">
+                                    {{ $professor->getFullName() }}
+                                </td>
+                                <!-- Correo -->
+                                <td class="px-6 py-4 text-[#231f20] dark:text-gray-300">
+                                    {{ $professor->email }}
+                                </td>
+                                <!-- Acciones -->
+                                <td class="px-6 py-4 text-center">
+                                    <div x-data="{ showModal{{ $professor->id }}: false }"
+                                         class="flex flex-col md:flex-row items-center justify-center gap-2">
+                                        <!-- Botón Ver -->
+                                        <button @click="showModal{{ $professor->id }} = true" title="{{ __('Ver detalles') }}" class="w-8 h-8 flex items-center justify-center bg-[#31c0d3] hover:bg-[#0b545b] dark:bg-[#0b545b] dark:hover:bg-[#31c0d3] text-white rounded-full transition">
+                                            <i class="fas fa-eye text-sm"></i>
+                                        </button>
+
+                                        <!-- Botón Editar -->
+                                        <a href="{{ route('professors.edit', $professor) }}" title="{{ __('Editar') }}" class="w-8 h-8 flex items-center justify-center bg-yellow-500 hover:bg-yellow-400 text-white rounded-full transition">
+                                            <i class="fas fa-pen text-sm"></i>
+                                        </a>
+
+                                        <!-- Botón Eliminar -->
+                                        <form action="{{ route('professors.destroy', $professor) }}" method="POST" id="delete-prof-{{ $professor->id }}" class="inline-block">
+                                            @csrf @method('DELETE')
+                                            <button type="button" class="swal-confirm w-8 h-8 flex items-center justify-center bg-red-600 hover:bg-red-500 text-white rounded-full transition" data-form-id="delete-prof-{{ $professor->id }}" data-title="{{ __('Eliminar profesor') }}" data-text="{{ __('¿Seguro que deseas eliminar a') }} {{ $professor->first_name }}?" data-icon="warning" data-confirm="{{ __('Sí, eliminar') }}" data-cancel="{{ __('Cancelar') }}" title="{{ __('Eliminar') }}">
+                                                <i class="fas fa-trash text-sm"></i>
+                                            </button>
+                                        </form>
+
+                                        <!-- Modal de vista -->
+                                        <div x-show="showModal{{ $professor->id }}" x-cloak @click.outside="showModal{{ $professor->id }} = false" x-transition.opacity class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+                                            <div @click.outside="showModal{{ $professor->id }} = false"
+                                                class="bg-white dark:bg-gray-900 text-gray-900 dark:text-white w-full max-w-2xl mx-4 p-6 rounded shadow-lg overflow-y-auto max-h-[90vh] transition-colors">
+                                                {{-- Header --}}
+                                                <div class="flex justify-between items-center mb-4">
+                                                    <h2 class="text-xl font-semibold">{{ __('Detalles del profesor') }}</h2>
+                                                    <button @click="showModal{{ $professor->id }} = false" class="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition text-xl">
+                                                        <i class="fa-solid fa-xmark"></i>
+                                                    </button>
+                                                </div>
+
+                                                <!-- Cuerpo del modal de vista -->
+                                                <div class="space-y-4 text-left">
+                                                    <div>
+                                                        <label class="block text-gray-700 dark:text-gray-300 mb-1">{{ __('Nombre') }}</label>
+                                                        <p class="text-gray-900 dark:text-gray-100 bg-gray-100 dark:bg-gray-800 px-3 py-2 rounded">
+                                                            {{ $professor->first_name }}
+                                                        </p>
+                                                    </div>
+                                                    <div>
+                                                        <label class="block text-gray-700 dark:text-gray-300 mb-1">{{ __('Apellido') }}</label>
+                                                        <p class="text-gray-900 dark:text-gray-100 bg-gray-100 dark:bg-gray-800 px-3 py-2 rounded">
+                                                            {{ $professor->last_name }}
+                                                        </p>
+                                                    </div>
+                                                    <div>
+                                                        <label class="block text-gray-700 dark:text-gray-300 mb-1">{{ __('Correo') }}</label>
+                                                        <p class="text-gray-900 dark:text-gray-100 bg-gray-100 dark:bg-gray-800 px-3 py-2 rounded">
+                                                            {{ $professor->email }}
+                                                        </p>
+                                                    </div>
+                                                </div>
+
+                                                <!-- Footer -->
+                                                <div class="mt-6 text-right">
+                                                    <button @click="showModal{{ $professor->id }} = false"
+                                                            class="bg-gray-200 hover:bg-[#31c0d3] text-gray-900 hover:text-white dark:bg-gray-600 dark:hover:bg-gray-500 dark:text-white px-4 py-2 rounded transition">
+                                                        {{ __('Cerrar') }}
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="3" class="px-6 py-4 text-center text-gray-400">
+                                    {{ __('No hay profesores registrados.') }}
+                                </td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+
+            {{-- Paginación --}}
+            <div class="mt-6">
+                {{ $professors->links() }}
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/professors/index.blade.php
+++ b/resources/views/professors/index.blade.php
@@ -3,8 +3,8 @@
     <x-slot name="header">
         <div class="flex items-center justify-between">
             <div class="flex items-center gap-3">
-                <span class="inline-flex items-center justifiy-center w-10 h-10 rounded-full bg-[#31c0d3]/20 dark:bg-[#0b545b]/30">
-                    <i class="fas fa-chalkboard-teacher text-xl text-[#31c0d3] dark:text-[#31c0d3] dark:bg-[#0b545b]/30 mr-2"></i>
+                <span class="inline-flex items-center justify-center w-10 h-10 rounded-full bg-[#31c0d3]/20 dark:bg-[#0b545b]/30">
+                    <i class="fas fa-chalkboard-teacher text-xl text-[#31c0d3] dark:text-[#31c0d3]"></i>
                 </span>
                 <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-100">
                     {{ __('Profesores') }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\ProfessorController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -17,6 +18,8 @@ Route::middleware(['auth', 'role:user,admin'])->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+
+    Route::resource('professors', ProfessorController::class);
 
     Route::view('/about', 'pages.about')
     ->name('about');


### PR DESCRIPTION
This PR includes the following:

- Implement the **Professor** model, migration, and ProfessorController with full CRUD actions, request validation, and password hashing
- Add index, create, and edit Blade views with a reusable __form partial_ to DRY up form markup.
- Leverage implicit model binding in routes and controllers instead of manual id lookups and try/catch blocks.
- Introduce a shared _alerts.blade.php_ partial powered by SweetAlert2 to centralize flash notifications
- Apply the institution’s color palette and ensure dark-mode support consistently across all Professors views

This establishes the foundational structure and styling conventions for the rest of the team to follow when building out additional models.